### PR TITLE
Fix note's subject modifiable

### DIFF
--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash');
 
+const validator = require('./validator/note')
+
 class Note {
     constructor(note) {
         this._note = note;
@@ -21,7 +23,9 @@ class Note {
     }
 
     async update(note) {
-        await this._note.update(note);
+        if(validator.validateNoteUpdateParams(note)) {
+	    await this._note.update(note);
+	}
     }
 
     async delete() {

--- a/src/domain/validator/note.js
+++ b/src/domain/validator/note.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const _ = require('lodash');
+
+
+function validateNoteUpdateParams(params) {
+    var valid = true;
+
+    // ToDo: Add other validate details
+
+    // Do not allow subject param 
+    valid = valid && !('subject' in params);
+
+    return valid;
+}
+
+module.exports = {
+    validateNoteUpdateParams,
+}

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -56,6 +56,19 @@ describe('Tests for domain Note', () => {
                     updatedAt: _.isDate,
                 });
             });
+
+	    it('should ignore updating the subject of the note', async() => {
+	        await domainNote.update({
+		    subject: 'new subject'
+		});
+
+	        domainNote.expose().should.match({
+		    id: noteId,
+		    subject: 'some subject',
+		    body: 'some body',
+		    updatedAt: _.isDate,
+		});
+	    });
         });
 
         describe('delete', () => {


### PR DESCRIPTION
This pull request addresses the problem of note's subject modifiable.

Because there was no mechanism to ensure validity of an update request,
a deliberate update request from authenticated user can modify subject
of a note, an action which should not be allowed.

The problem can be replicated by executing the following script in a browser
after logged in.

var xHttp = new XMLHttpRequest();

xHttp.open('PUT', 'api/notes/20');
xHttp.setRequestHeader('Content-Type', 'application/json');

xHttp.onload = function() {
  if(xHttp.status ===200) {
    alert('Done!');
  }
};

xHttp.send(JSON.stringify({
  subject: "New Subject"
}));

The above script modifies subject of a note with id 20.

To address the above mentioned problem, there are 2 options which
were considered, adding mechanism to check the incoming request
parameter, or update the data update process to execute only specific
update parameter. The former option can be broad in term of details
to check, however, it can completely filter a request deemed illegitimate.
On the other hand, a latter option allow a strict control of details which
can be update, however, it may allow part of an illegitimate update request
to be executed.
As a result, the addition of request parameter validation mechanism is applied.

From what has been confirmed, there was no mechanism for checking
any of the incoming request details. This can leads to other unintended
actions for note update and other features.

Therefore, validation for every request details should be performed the prevent
complications to occur.